### PR TITLE
Update dep to 0.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ cache:
   - vendor
 
 before_install:
-  - go get -u github.com/golang/dep/cmd/dep
+  # install dep
+  - curl -L https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 > $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
 
 install:
   - dep ensure -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.7
   - 1.8
+  - 1.9
 
 cache:
   - vendor


### PR DESCRIPTION
Updating to dep `0.3.2` and installing binary release from github rather than through `go get`.