### PR TITLE
Better error when port unavailable

### DIFF
--- a/server.go
+++ b/server.go
@@ -35,7 +35,7 @@ func New(address string, options ...func(*server)) (Server, error) {
 		return nil, errors.New("[StatsD] Invalid address")
 	}
 
-	conn, _ := net.ListenUDP("udp", addr)
+	conn, err := net.ListenUDP("udp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("[StatsD] Unable to listen at udp: %s", address)
 	}


### PR DESCRIPTION
Fix an (apparently) small typo in capture error when doing port binding to give this error:
```
panic: [StatsD] Unable to listen at udp: 0.0.0.0:8125

goroutine 1 [running]:
main.main()
    /home/theist/go/src/github.com/catkins/statsd-logger/cmd/statsd-logger/main.go:17
    +0x18a
```

Without this PR the server ends with this message:
```
[StatsD] Listening on port 8125
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d5302]

goroutine 7 [running]:
github.com/catkins/statsd-logger.(*server).Listen(0xc420064100, 0x0,
    0x0)
    /home/theist/go/src/github.com/catkins/statsd-logger/server.go:96
    +0x132
    main.main.func1(0x533840, 0xc420064100)
    /home/theist/go/src/github.com/catkins/statsd-logger/cmd/statsd-logger/main.go:21
    +0x31
    created by main.main
      /home/theist/go/src/github.com/catkins/statsd-logger/cmd/statsd-logger/main.go:20
      +0x13b
```